### PR TITLE
Update fork-sync.yaml

### DIFF
--- a/.github/workflows/fork-sync.yaml
+++ b/.github/workflows/fork-sync.yaml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    timeout-minutes: 30 # `yarn test` takes longer time
+    timeout-minutes: 30
     steps:
       - uses: tgymnich/fork-sync@v2.0.10
         with:
@@ -20,5 +20,5 @@ jobs:
           head: master
           base: master
           auto_merge: false
-          pr_title: Sync with upstream repo [$(date +'%Y-%m-%d')]
-          pr_message: Merge latest changes from upstream repo [$(date +'%Y-%m-%d')]
+          pr_title: Sync with upstream repo
+          pr_message: Merge latest changes from upstream repo


### PR DESCRIPTION
The unix commands do work on the fork-sync workflow. Hence, updating the workflow definition.